### PR TITLE
Trained with Park from scratch and inference done on test images

### DIFF
--- a/Splicing/data/AbstractDataset.py
+++ b/Splicing/data/AbstractDataset.py
@@ -113,6 +113,12 @@ class AbstractDataset(ABC):
         if mask is None:
             mask = np.zeros((h, w))
 
+        if isinstance(mask, int):
+            if mask == 0:
+                mask = np.zeros((h, w))
+            else:
+                mask = np.ones((h, w))
+
         if self._crop_size is None and self._grid_crop:
             crop_size = (-(-h//8) * 8, -(-w//8) * 8)  # smallest 8x8 grid crop that contains image
         elif self._crop_size is None and not self._grid_crop:
@@ -155,7 +161,7 @@ class AbstractDataset(ABC):
 
             # crop mask
             mask = mask[s_r:s_r + crop_size[0], s_c:s_c + crop_size[1]]
-
+            
             # crop DCT_coef
             if 'DCTcoef' in self._blocks or 'DCTvol' in self._blocks or 'rawRGB' in self._blocks:
                 for i in range(self.DCT_channels):
@@ -193,7 +199,7 @@ class AbstractDataset(ABC):
 
         # final tensor
         tensor = torch.cat(img_block)
-
+        
         if 'qtable' not in self._blocks:
             return tensor, torch.tensor(mask, dtype=torch.long), 0
         else:

--- a/Splicing/data/Djpeg_test_inference.txt
+++ b/Splicing/data/Djpeg_test_inference.txt
@@ -1,0 +1,76 @@
+/media/VA/BM_tmp/databases/Park/single/S_328386_1084.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_106465_380.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_553342_593.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_488187_228.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_238329_651.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_036945_81.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_208877_143.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_485765_809.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_551846_592.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_150946_921.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_202123_523.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_194518_292.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_437856_678.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_048805_456.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_471193_282.jpg,0
+/media/VA/BM_tmp/databases/Park/single/S_377892_927.jpg,0
+/media/VA/BM_tmp/databases/Park/double/D_312683_121_137.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_482906_1044_894.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_354823_214_1108.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_388224_506_220.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_177482_755_718.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_291792_1158_686.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_070503_234_579.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_436249_1134_977.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_131368_231_1070.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_067443_1116_821.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_391015_315_544.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_385175_161_805.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_479011_232_886.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_552033_503_735.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_519935_512_928.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_329159_569_1161.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_093714_731_415.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_438707_1089_1143.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_127985_567_733.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_019403_196_324.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_172558_406_652.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_078007_758_584.jpg,1
+/media/VA/BM_tmp/databases/Park/double/D_409068_315_840.jpg,1
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000016.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000057.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000251.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000329.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000447.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000461.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000535.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000549.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000570.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/0_COCO_test2014_000000000890.jpg, 0
+/media/BM/databases/DEFACTO-12K/images/1_11_000000268058.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000322029.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000341132.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000345400.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000429706.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000432607.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000434900.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000489088.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000513319.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/1_11_000000552563.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5207_000000146672.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5211_000000295116.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5218_000000259426.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5232_000000271934.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5233_000000466273.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5254_000000125886.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5257_000000041322.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_526_000000348087.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5302_000000086845.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5304_000000261906.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5329_000000217156.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5336_000000134213.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5355_000000034126.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5359_000000014412.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5372_000000261783.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5375_000000348234.jpg, 1
+/media/BM/databases/DEFACTO-12K/images/2_5384_000000385535.jpg, 1

--- a/Splicing/data/data_core.py
+++ b/Splicing/data/data_core.py
@@ -13,6 +13,7 @@ from Splicing.data.dataset_FantasticReality import FantasticReality
 from Splicing.data.dataset_IMD2020 import IMD2020
 from Splicing.data.dataset_CASIA import CASIA
 from Splicing.data.dataset_COCOannot import COCOannot
+from Splicing.data.dataset_Park import Park
 # from Splicing.data.dataset_DEFACTO import DEFACTO
 # from Splicing.data.dataset_tampCOCO import tampCOCO
 # from Splicing.data.dataset_NC16 import NC16
@@ -40,7 +41,8 @@ class SplicingDataset(Dataset):
             # self.dataset_list.append(tampCOCO(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/bcmc_COCO_train_list.txt"))
             # self.dataset_list.append(compRAISE(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/compRAISE_train.txt"))
             # self.dataset_list.append(DEFACTO(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/defacto12k.txt"))
-            self.dataset_list.append(COCOannot(crop_size, grid_crop, blocks, DCT_channels, "defacto_train.txt", True))
+            # self.dataset_list.append(COCOannot(crop_size, grid_crop, blocks, DCT_channels, "defacto_train.txt", True))
+            self.dataset_list.append(Park(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/Djpeg_train.txt"))
 
         elif mode == "valid":
             # self.dataset_list.append(FantasticReality(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/FR_valid_list.txt"))
@@ -54,14 +56,15 @@ class SplicingDataset(Dataset):
             # self.dataset_list.append(tampCOCO(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/bcmc_COCO_valid_list.txt"))
             # self.dataset_list.append(compRAISE(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/compRAISE_valid.txt"))
             # self.dataset_list.append(DEFACTO(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/defacto150.txt"))
-            self.dataset_list.append(COCOannot(crop_size, grid_crop, blocks, DCT_channels, "defacto_val_tamp.txt", False))
+            self.dataset_list.append(Park(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/Djpeg_test.txt"))
 
         elif mode == "arbitrary":
-            self.dataset_list.append(arbitrary(crop_size, grid_crop, blocks, DCT_channels, "./input//*", read_from_jpeg=read_from_jpeg))
+            #self.dataset_list.append(arbitrary(crop_size, grid_crop, blocks, DCT_channels, "./input//*", read_from_jpeg=read_from_jpeg))
             # self.dataset_list.append(arbitrary(crop_size, grid_crop, blocks, DCT_channels, "/home/dperez/workspace/forgeries_database/forgeries/genuine//*", read_from_jpeg=read_from_jpeg))
             # self.dataset_list.append(arbitrary(crop_size, grid_crop, blocks, DCT_channels, "/home/dperez/workspace/forgeries_database/forgeries/copymove//*", read_from_jpeg=read_from_jpeg))
             # self.dataset_list.append(arbitrary(crop_size, grid_crop, blocks, DCT_channels, "/home/dperez/workspace/bbdd/ariadnext/GRADIANT_EVALUATION//*", read_from_jpeg=read_from_jpeg))
-        else:
+            self.dataset_list.append(Park(crop_size, grid_crop, blocks, DCT_channels, "Splicing/data/Djpeg_test_inference.txt"))
+        else:   
             raise KeyError("Invalid mode: " + mode)
         if class_weight is None:
             self.class_weights = torch.FloatTensor([1.0, 1.0])

--- a/Splicing/data/dataset_Park.py
+++ b/Splicing/data/dataset_Park.py
@@ -1,0 +1,29 @@
+"""
+Created by Myung-Joon Kwon
+mjkwon2021@gmail.com
+Aug 4, 2020
+
+This dataset is used for pretraining the DCT stream on double JPEG detection.
+"""
+import project_config
+from Splicing.data import AbstractDataset
+
+
+class Park(AbstractDataset.AbstractDataset):
+    def __init__(self, crop_size, grid_crop, blocks: list, DCT_channels: int, tamp_list: str):
+        """
+        :param crop_size: (H,W) or None
+        :param blocks:
+        :param tamp_list: EX: "Splicing/data/Park_train.txt"
+        :param read_from_jpeg: F=from original extension, T=from jpeg compressed image
+        """
+        super().__init__(crop_size, grid_crop, blocks, DCT_channels)
+        self._root_path = project_config.dataset_paths['Park']
+        with open("/home/rroman/workspace/CAT-Net/"+tamp_list, "r") as f:
+            self.tamp_list = [t.strip().split(',') for t in f.readlines()]
+
+    def get_tamp(self, index):
+        assert 0 <= index < len(self.tamp_list), f"Index {index} is not available!"
+        tamp_path = self._root_path / self.tamp_list[index][0]
+        return self._create_tensor(tamp_path, int(self.tamp_list[index][1]))
+

--- a/experiments/CAT_DCT_only.yaml
+++ b/experiments/CAT_DCT_only.yaml
@@ -14,8 +14,7 @@ DATASET:
 MODEL:
   NAME: network_DCT
   PRETRAINED_RGB: 'pretrained_models/hrnetv2_w48_imagenet_pretrained.pth'
-  PRETRAINED_DCT: 'output/splicing_dataset/CAT_full/CAT_full_v2.pth.tar'
-  # PRETRAINED_DCT: 'pretrained_models/DCT_djpeg.pth.tar'
+  PRETRAINED_DCT: ''
   EXTRA:
     FINAL_CONV_KERNEL: 1
     STAGE1:
@@ -111,9 +110,9 @@ LOSS:
   OHEMKEEP: 131072
 TRAIN:
   IMAGE_SIZE:
-  - 512
-  - 512
-  BASE_SIZE: 512
+  - 256
+  - 256
+  BASE_SIZE: 256
   BATCH_SIZE_PER_GPU: 11
   SHUFFLE: true
   BEGIN_EPOCH: 0
@@ -131,9 +130,9 @@ TRAIN:
   SCALE_FACTOR: 11
 TEST:
   IMAGE_SIZE:
-  - 512
-  - 512
-  BASE_SIZE: 512
+  - 256
+  - 256
+  BASE_SIZE: 256
   BATCH_SIZE_PER_GPU: 22
   NUM_SAMPLES: 2000
   FLIP_TEST: false

--- a/project_config.py
+++ b/project_config.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 
 project_root = Path(__file__).parent
-dataset_root = Path(r"/media/BM/databases/")
+dataset_root = Path(r"/media/VA/BM_tmp/databases/")
 dataset_paths = {
     # Specify where are the roots of the datasets.
     #'FR': dataset_root / "FantasticReality_v1",
@@ -23,7 +23,8 @@ dataset_paths = {
     'COCOannot_images_val': dataset_root / "DEFACTO-12K/images/",
     'COCOannot_masks_val': "results/data/transform/coco_to_mmsegmentation-defacto/masks/val/",
     'COCOannot_list': "results/data/transform/coco_to_mmsegmentation-defacto/",
-
+    'Park': dataset_root / "Park/",
+    
     # 'compRAISE': dataset_root / "compRAISE",
     # 'COVERAGE': dataset_root / "COVERAGE",
     # 'CoMoFoD': dataset_root / "CoMoFoD_small_v2",

--- a/results/experiment.json
+++ b/results/experiment.json
@@ -1,0 +1,1 @@
+{"artifact_uri": "/media/VA/mlruns/81/5bbc5af0c1df48a1a08e6d97b2ed428d/artifacts", "timestamp": "20220610_142513"}

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -63,14 +63,13 @@ def main():
     # Instead of using argparse, force these args:
 
     ## CHOOSE ##
-    FULL_OPT = True
+    FULL_OPT = False
     ##working option
-    if FULL_OPT:
-        args = argparse.Namespace(cfg='experiments/CAT_full.yaml', opts=['TEST.MODEL_FILE', 'output/splicing_dataset/CAT_full/CAT_full_v2.pth.tar', 'TEST.FLIP_TEST', 'False', 'TEST.NUM_SAMPLES', '0'])
-    else:    
-        args = argparse.Namespace(cfg='experiments/CAT_DCT_only.yaml', opts=['TEST.MODEL_FILE', 'output/splicing_dataset/CAT_full/CAT_full_v2.pth.tar', 'TEST.FLIP_TEST', 'False', 'TEST.NUM_SAMPLES', '0'])
-
-    # args = argparse.Namespace(cfg='experiments/CAT_DCT_only.yaml', opts=['TEST.MODEL_FILE', 'output/splicing_dataset/CAT_DCT_only/DCT_only_v2.pth.tar', 'TEST.FLIP_TEST', 'False', 'TEST.NUM_SAMPLES', '0'])
+    # if FULL_OPT:
+    #     args = argparse.Namespace(cfg='experiments/CAT_full.yaml', opts=['TEST.MODEL_FILE', 'output/splicing_dataset/CAT_full/CAT_full_v2.pth.tar', 'TEST.FLIP_TEST', 'False', 'TEST.NUM_SAMPLES', '0'])
+    # else:    
+    #     args = argparse.Namespace(cfg='experiments/CAT_DCT_only.yaml', opts=['TEST.MODEL_FILE', 'output/splicing_dataset/CAT_full/CAT_full_v2.pth.tar', 'TEST.FLIP_TEST', 'False', 'TEST.NUM_SAMPLES', '0'])
+    args = argparse.Namespace(cfg='experiments/CAT_DCT_only.yaml', opts=['TEST.MODEL_FILE', 'output/splicing_dataset/CAT_DCT_only/checkpoint.pth.tar', 'TEST.FLIP_TEST', 'False', 'TEST.NUM_SAMPLES', '0'])
     update_config(config, args)
 
     # cudnn related setting

--- a/tools/train.py
+++ b/tools/train.py
@@ -67,8 +67,8 @@ def train_model():
     # args = parse_args()
     # Instead of using argparse, force these args:
     ## CHOOSE ##
-    args = argparse.Namespace(cfg='experiments/CAT_full.yaml', local_rank=0, opts=None)
-    # args = argparse.Namespace(cfg='experiments/CAT_DCT_only.yaml', local_rank=0, opts=None)
+    # args = argparse.Namespace(cfg='experiments/CAT_full.yaml', local_rank=0, opts=None)
+    args = argparse.Namespace(cfg='experiments/CAT_DCT_only.yaml', local_rank=0, opts=None)
 
     update_config(config, args)
 
@@ -104,8 +104,8 @@ def train_model():
     crop_size = (config.TRAIN.IMAGE_SIZE[1], config.TRAIN.IMAGE_SIZE[0])
     if config.DATASET.DATASET == 'splicing_dataset':
         ## CHOOSE ##
-        train_dataset = splicing_dataset(crop_size=crop_size, grid_crop=True, blocks=('RGB', 'DCTvol', 'qtable'), mode='train', DCT_channels=1, read_from_jpeg=True, class_weight=[0.5, 2.5])  # full model
-        # train_dataset = splicing_dataset(crop_size=crop_size, grid_crop=True, blocks=('DCTvol', 'qtable'), mode='train', DCT_channels=1, read_from_jpeg=True, class_weight=[0.5, 2.5])  # only DCT stream
+        #train_dataset = splicing_dataset(crop_size=crop_size, grid_crop=True, blocks=('RGB', 'DCTvol', 'qtable'), mode='train', DCT_channels=1, read_from_jpeg=True, class_weight=[0.5, 2.5])  # full model
+        train_dataset = splicing_dataset(crop_size=crop_size, grid_crop=True, blocks=('DCTvol', 'qtable'), mode='train', DCT_channels=1, read_from_jpeg=True, class_weight=[0.5, 2.5])  # only DCT stream
         logger.info(train_dataset.get_info())
     else:
         raise ValueError("Not supported dataset type.")
@@ -120,8 +120,8 @@ def train_model():
 
     # validation
     ## CHOOSE ##
-    valid_dataset = splicing_dataset(crop_size=None, grid_crop=True, blocks=('RGB', 'DCTvol', 'qtable'), mode="valid", DCT_channels=1, read_from_jpeg=True)  # full model
-    # valid_dataset = splicing_dataset(crop_size=None, grid_crop=True, blocks=('DCTvol', 'qtable'), mode="valid", DCT_channels=1, read_from_jpeg=True)  # only DCT stream
+    # valid_dataset = splicing_dataset(crop_size=None, grid_crop=True, blocks=('RGB', 'DCTvol', 'qtable'), mode="valid", DCT_channels=1, read_from_jpeg=True)  # full model
+    valid_dataset = splicing_dataset(crop_size=None, grid_crop=True, blocks=('DCTvol', 'qtable'), mode="valid", DCT_channels=1, read_from_jpeg=True)  # only DCT stream
 
     print(" ***=> DATALOADER val")
 


### PR DESCRIPTION
Closes #8 
Trained CATNet's DCT stream using Park's data.
Modifications:
- Image size changed to 256x256 to avoid padding affecting the predictions.
- Splicing/data/dataset_Park.py created to handle data from Park dataset.
- Splicing/data/AbstractDataset.py modified so that when it receives an int value instead of a mask a new mask of zeros or ones is created.

Inference was performed as well using images from Park and DEFACTO.
MLFlow link: http://10.10.30.58:8999/#/experiments/81/runs/b66ec318eee648a1adf73013977dd7f3